### PR TITLE
Add variable handling to analysis

### DIFF
--- a/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/src/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/RunCustomJavaBasedAnalysisJob.java
+++ b/bundles/edu.kit.kastel.dsis.fluidtrust.dataflow.analysis/src/edu/kit/kastel/dsis/fluidtrust/dataflow/analysis/RunCustomJavaBasedAnalysisJob.java
@@ -85,21 +85,29 @@ public class RunCustomJavaBasedAnalysisJob extends AbstractBlackboardInteracting
 
 		for (var resultEntry : allCharacteristics.getResults().entrySet()) {
 			for (var queryResult : resultEntry.getValue()) {
+				
+				var availableVariables = queryResult.getDataCharacteristics().keySet();
+				
+				for (String variable : availableVariables) {
+					var grantedRoles = queryResult.getDataCharacteristics()
+							.get(variable)
+							.stream()
+							.filter(cv -> cv.getCharacteristicType() == ctGrantedRoles)
+							.map(CharacteristicValue::getCharacteristicLiteral).map(it -> it.getName())
+							.collect(Collectors.toList());
+					
+					var assignedRoles = queryResult.getNodeCharacteristics()
+							.stream()
+							.filter(cv -> cv.getCharacteristicType() == ctAssignedRoles)
+							.map(val -> val.getCharacteristicLiteral()).map(it -> it.getName())
+							.collect(Collectors.toList());
 
-				var grantedRoles = queryResult.getDataCharacteristics().values().stream()
-						.flatMap(Collection::stream)
-						.filter(cv -> cv.getCharacteristicType() == ctGrantedRoles)
-						.map(CharacteristicValue::getCharacteristicLiteral).map(it -> it.getName())
-						.collect(Collectors.toList());
+					var element = getElementRepresentation(queryResult.getElement());
 
-				var assignedRoles = queryResult.getDataCharacteristics().values().stream()
-						.flatMap(Collection::stream).filter(cv -> cv.getCharacteristicType() == ctAssignedRoles)
-						.map(val -> val.getCharacteristicLiteral()).map(it -> it.getName())
-						.collect(Collectors.toList());
+					System.out.println(element + ", " + variable + ", " + grantedRoles.toString() + ", " + assignedRoles.toString());
+				}
 
-				var element = getElementRepresentation(queryResult.getElement());
-
-				System.out.println(element + ", " + grantedRoles.toString() + ", " + assignedRoles.toString());
+				
 
 				// Actual constraint
 				/*if (serverLocations.contains("nonEU") && dataSensitivites.contains("Personal")) {


### PR DESCRIPTION
Der bisherige Testcode ist immer von einer einzigen Variable ausgegangen, weswegen alle Charaktersitiken gemerged wurden. Das ist im Fall des Travel Planners natürlich nicht korrekt, weil es `ccd` und `flight` gibt. Ich habe das entsprechend behoben.

Noch offenes Problem: Beim Handling des `ccd` sollte irgendwo mal `assignedRole = Airline` auftauchen, bisher ist das immer `asssignedRole = User`. Ich nehme an, dass eine einzige Variable, die ccd in der book Funktion der Komponente AirlineLogic nutzt, ausreicht, um das zu provozieren, womit die Verletzung gefunden würde. Ich kann das nur leider nicht testen, weil du eine neuere Version der Sirius Editoren nutzt als ich in meiner Installation habe (und ich nicht riskieren werde die Installation zu zerlegen :))